### PR TITLE
Got things to compile without opengl and fixed issue from rustfmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "image",
  "lazy_static",
  "object-pool",
+ "pancurses",
  "parking_lot 0.10.2",
  "rand",
  "ultraviolet",
@@ -866,6 +867,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a785740271256c230f57462d3b83e52f998433a7062fc18f96d5999474a9f915"
 
 [[package]]
+name = "ncurses"
+version = "5.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15699bee2f37e9f8828c7b35b2bc70d13846db453f2d507713b758fabe536b82"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "ndk"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1054,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pancurses"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3058bc37c433096b2ac7afef1c5cdfae49ede0a4ffec3dfc1df1df0959d0ff0"
+dependencies = [
+ "libc",
+ "log",
+ "ncurses",
+ "pdcurses-sys",
+ "winreg",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1114,16 @@ dependencies = [
  "redox_syscall",
  "smallvec 1.4.0",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "pdcurses-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084dd22796ff60f1225d4eb6329f33afaf4c85419d51d440ab6b8c6f4529166b"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1809,6 +1844,15 @@ dependencies = [
  "web-sys",
  "winapi 0.3.8",
  "x11-dl",
+]
+
+[[package]]
+name = "winreg"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
+dependencies = [
+ "winapi 0.3.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,12 @@ edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["opengl"]
+curses = ["rltk/curses"]
+opengl = ["rltk/opengl"]
+
 [dependencies]
-rltk = {version = "0.8.0"}
+rltk = {version = "0.8.0", default-features=false }
 specs = "0.16.1"
 specs-derive = "0.4.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -9,7 +9,6 @@ reorder_impl_items = true
 wrap_comments = true
 normalize_comments = true
 error_on_unformatted = true
-normalize_doc_attributes = true
 
 # Ignore generated files
 ignore =  ["**/*_generated.rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@ use specs::prelude::*;
 mod component;
 pub use component::*;
 mod map;
-pub use map::*;
+use map::*;
 mod player;
 use player::*;
 mod rect;
-pub use rect::Rect;
+use rect::Rect;
 
 pub struct State {
     pub ecs: World,


### PR DESCRIPTION
Now, we can run the code without opengl if we want to, using the `curses` backend. Try doing 
`cargo run --no-default-features --features curses`. Things should work as they usually do if you don't specify any features.

Feel free to click the "merge" button! I didn't want to merge anything you didn't get a chance to see :)